### PR TITLE
Update after adding new repository

### DIFF
--- a/ubuntu/14.04/Dockerfile
+++ b/ubuntu/14.04/Dockerfile
@@ -7,6 +7,7 @@ LABEL description="Run ansible roles and playbooks"
 RUN apt-get -y update \
     && apt-get install software-properties-common -y \
     && apt-add-repository ppa:ansible/ansible \
+    && apt-get -y update \
     && apt-get install -y ansible wget \
     && apt-get clean \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -7,6 +7,7 @@ LABEL description="Run ansible roles and playbooks"
 RUN apt-get -y update \
     && apt-get install software-properties-common -y \
     && apt-add-repository ppa:ansible/ansible \
+    && apt-get -y update \
     && apt-get install -y ansible wget \
     && apt-get clean \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts


### PR DESCRIPTION
Without `apt-get update` after `apt-add-repository` the PPA contents are not seen and in consequence, the Ansible is installed in 1.5.4 version instead of the latest 2.x branch.
